### PR TITLE
Allow container logging via the local host rsyslog

### DIFF
--- a/transpose_compose.rb
+++ b/transpose_compose.rb
@@ -90,7 +90,6 @@ class Service
     @defn['logging'] = {
       "driver" => "syslog",
       "options" => {
-        "syslog-address" => "udp://rsyslog.priv:514",
         "tag" => "peer-#{build_name}-#{@name}"
       }
     }


### PR DESCRIPTION
Allows us to use the local host rsyslog daemon for spooling and sending
logs via TCP and TLS to loggly or other sources.