### PR TITLE
allow for service.json env vars to override the defaults from ecs-composer

### DIFF
--- a/transpose_compose.rb
+++ b/transpose_compose.rb
@@ -117,7 +117,7 @@ class Service
   end
 
   def add_peer_env(config)
-    @defn["environment"] << "APP_NAME=#{app_name}" unless @defn["environment"].any? { |e| e.include?('APP_NAME') }
+    @defn["environment"] << "APP_NAME=#{app_name}" unless @defn["environment"].any? { |e| e.start_with?('APP_NAME=') }
     @defn["environment"] << "APP_ENV=peer-#{build_name}"
     @defn["environment"] << "VAULT_ADDR=http://vault.priv"
     @defn["environment"] << "CONSUL_ADDR=consul.priv:8500"

--- a/transpose_compose.rb
+++ b/transpose_compose.rb
@@ -54,8 +54,6 @@ class Service
       prepare_system if is_app?
       delay_for_database if db_required?
     end
-
-    @defn
   end
 
   def base_command
@@ -170,9 +168,7 @@ end
 
 compose = YAML.load_file('docker-compose.yml')
 compose["services"].each do |service_name, details|
-  service = Service.new(service_name, details)
-
-  compose["services"][service_name] = service.serialize!(peer_config)
+  Service.new(service_name, details).serialize!(peer_config)
 end
 
 File.open('docker-compose-ecs.yml', 'w') {|f| f.write compose.to_yaml }

--- a/transpose_compose.rb
+++ b/transpose_compose.rb
@@ -47,6 +47,8 @@ class Service
     ensure_image
     convert_links
     add_peer_env(config)
+    setup_env(config)
+    mount_volumes(config)
 
     build_command do
       prepare_system if is_app?
@@ -169,9 +171,6 @@ end
 compose = YAML.load_file('docker-compose.yml')
 compose["services"].each do |service_name, details|
   service = Service.new(service_name, details)
-
-  service.setup_env(peer_config)
-  service.mount_volumes(peer_config)
 
   compose["services"][service_name] = service.serialize!(peer_config)
 end

--- a/transpose_compose.rb
+++ b/transpose_compose.rb
@@ -46,8 +46,8 @@ class Service
     ensure_mem_limits
     ensure_image
     convert_links
-    add_peer_env(config)
     setup_env(config)
+    add_peer_env(config)
     mount_volumes(config)
 
     build_command do
@@ -117,7 +117,7 @@ class Service
   end
 
   def add_peer_env(config)
-    @defn["environment"] << "APP_NAME=#{app_name}"
+    @defn["environment"] << "APP_NAME=#{app_name}" unless @defn["environment"].any? { |e| e.include?('APP_NAME') }
     @defn["environment"] << "APP_ENV=peer-#{build_name}"
     @defn["environment"] << "VAULT_ADDR=http://vault.priv"
     @defn["environment"] << "CONSUL_ADDR=consul.priv:8500"


### PR DESCRIPTION
there are cases, particularly for rise-runtime, where a peer will need to access environment variables from different namespaces for risecom vs 360 rise based on the `APP_NAME`; this change will allow the `APP_NAME` from service.json to override the default value set by `ecs-composer.rb`