### PR TITLE
add ability to pass additional fields via service.json to peer task

### DIFF
--- a/transpose_compose.rb
+++ b/transpose_compose.rb
@@ -35,6 +35,14 @@ class Service
     end
   end
 
+  def add_additional_fields(config)
+    if config["additional_fields"] && config["additional_fields"][@name]
+      config["additional_fields"][@name].each do |field, value|
+        @defn[field] = value
+      end
+    end
+  end
+
   def mount_volumes(config)
     if config["volumes"] && config["volumes"][@name]
       config["volumes"][@name].each do |container_path|
@@ -52,6 +60,7 @@ class Service
     setup_env(config)
     add_peer_env(config)
     mount_volumes(config)
+    add_additional_fields(config)
 
     build_command do
       prepare_system if is_app?


### PR DESCRIPTION
Adding the ability to pass additional fields to peer ECS task definitions via service.json so we can do things like mark containers as `essential: false`; we can't specify fields like that in docker-compose.yml so we have to do it this way before converting the `docker-compose-ecs.yml` file to the ECS task definition via the [container-transform](https://github.com/articulate/container-transform) container during peer deploys.