### PR TITLE
add ability to specify shell other than bash

### DIFF
--- a/transpose_compose.rb
+++ b/transpose_compose.rb
@@ -69,7 +69,7 @@ class Service
     mount_volumes(config)
     add_additional_fields(config)
 
-    build_command do
+    build_command(config) do
       prepare_system if is_app?
       delay_for_database if db_required?
     end
@@ -179,7 +179,7 @@ class Service
     @command.unshift "make peer-prepare"
   end
 
-  def build_command
+  def build_command(config)
     command = @defn["command"]
 
     # use the Dockerfile command if we're the app and nothing is yet specified
@@ -192,7 +192,8 @@ class Service
     if !command.nil?
       @command = Array(command)
       yield
-      @command = ["bash", "-c", @command.join(" && ")]
+      shell = config["shells"] && config["shells"][@name] ? config["shells"][@name] : "bash"
+      @command = ["#{shell}", "-c", @command.join(" && ")]
       @defn['command'] = @command
     else
       # No command modification


### PR DESCRIPTION
we need to be able to specify shells other than `bash` to run some containers for images that we don't control and that don't have bash preinstalled on them already.

![](https://p-BOFBBg.b4.n0.cdn.getcloudapp.com/items/OAuL6XwX/Image+2020-01-09+at+1.27.59+PM.png?v=f0713ea2bbf6d764dc22354949a8719a)

Example block in service.json to specify the `sh` shell for a service called `tf` would look like the following:

```
{
  "peer": {
    "shells": {
      "tf": "sh"
    }
}
```


