### PR TITLE
Update peer to set SERVICE_ENV and SERVICE_NAME to work with latest docker-consul-template-bootstrap

### DIFF
--- a/transpose_compose.rb
+++ b/transpose_compose.rb
@@ -147,8 +147,10 @@ class Service
 
   def add_peer_env(config)
     @defn["environment"] << "APP_NAME=#{app_name}" unless @defn["environment"].any? { |e| e.start_with?('APP_NAME=') }
+    @defn["environment"] << "SERVICE_NAME=#{app_name}" unless @defn["environment"].any? { |e| e.start_with?('SERVICE_NAME=') }
     @defn["environment"] << "SERVICE_PRODUCT=#{product_name}" unless @defn["environment"].any? { |e| e.start_with?('SERVICE_PRODUCT=') }
     @defn["environment"] << "APP_ENV=peer-#{build_name}"
+    @defn["environment"] << "SERVICE_ENV=peer-#{build_name}" unless @defn["environment"].any? { |e| e.start_with?('SERVICE_ENV=') }
     @defn["environment"] << "VAULT_ADDR=#{vault_address}"
     @defn["environment"] << "CONSUL_ADDR=#{consul_address}"
     @defn["environment"] << "SYSTEM_URL=#{service_host}"


### PR DESCRIPTION
These old environment variables were deprecated in https://github.com/articulate/docker-consul-template-bootstrap/commit/83e23e51178427f3d513a27750bc392777eb127b#, but were not updated here.